### PR TITLE
fix: Make sure `$jwtexplode->scp` is defined

### DIFF
--- a/src/Provider/EveOnline.php
+++ b/src/Provider/EveOnline.php
@@ -76,7 +76,9 @@ class EveOnline extends AbstractProvider
         $response['CharacterID']=$characterid;
         $response['CharacterOwnerHash']=$jwtexplode->owner;
         $response['ExpiresOn']=date('Y-m-d\TH:i:s',$jwtexplode->exp);
-        $response['Scopes']=implode(" ",$jwtexplode->scp);
+        if (isset($jwtexplode->scp)) {
+            $response['Scopes']=implode(" ",$jwtexplode->scp);
+        }
 
         return $this->createResourceOwner($response, $token);
     }


### PR DESCRIPTION
If scope is not specified when requesting, the returned JWT will not include scp. So `implode(" ",$jwtexplode->scp)` will trigger a warning.